### PR TITLE
Fix disabling of filters in latest active_admin

### DIFF
--- a/lib/active_admin/mongoid/resource.rb
+++ b/lib/active_admin/mongoid/resource.rb
@@ -10,9 +10,11 @@ end
 
 ActiveAdmin::ResourceController # autoload
 class ActiveAdmin::ResourceController
-  # Disable filters
-  def initialize
-    super
+  before_filter :skip_sidebar!
+
+  protected
+
+  def skip_sidebar!
     @skip_sidebar = true
   end
 


### PR DESCRIPTION
In the latest active_admin, [this code](https://github.com/gregbell/active_admin/blob/master/lib/active_admin/filters/resource_extension.rb#L85) expects `@search` to be set. This gem doesn't set it (because of its monkey patch to the `search` method), and AA fails with the following as a result:

```
undefined method `base' for nil:NilClass
```

The reason is that the way in which this gem disables the sidebar no longer works. This patch uses a better way of disabling the sidebar (filters), so that the above error doesn't occur.
