### PR TITLE
Added filter support and tests for string, date_range, numeric, select, and check_boxes filters.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,12 @@ group :assets do
 end
 
 gem 'jquery-rails'
+gem 'jquery-ui-rails'
 gem 'jslint'
 
 group :test do
   gem 'capybara'
+  gem 'poltergeist'
   gem 'launchy'
+  gem 'simplecov', require: false
 end

--- a/lib/meta_search/searches/mongoid.rb
+++ b/lib/meta_search/searches/mongoid.rb
@@ -15,10 +15,48 @@ module MetaSearch
 
       def build
         params.each_pair do |field_query, value|
-          field, query = field_query.scan(metasearch_regexp).first
+          field, query = field_query.to_s.scan(metasearch_regexp).first
           case query.to_sym
-          when :contains
+          when :equals, :eq
+            @relation = relation.where(field => value)
+          when :does_not_equal, :ne, :not_eq
+            @relation = relation.where(field.to_sym.ne => value)
+          when :contains, :like, :matches
             @relation = relation.where(field => /#{value}/)
+          when :does_not_contain, :nlike, :not_matches
+            @relation = relation.where(field.to_sym.not => /#{value}/)
+          when :starts_with, :sw
+            @relation = relation.where(field.to_sym => /\A#{Regexp.quote(value)}/)
+          when :does_not_start_with, :dnsw
+            @relation = relation.where(field.to_sym.not => /\A#{Regexp.quote(value)}/)
+          when :ends_with, :ew
+            @relation = relation.where(field.to_sym => /#{Regexp.quote(value)}\z/)
+          when :does_not_end_with, :dnew
+            @relation = relation.where(field.to_sym.not => /#{Regexp.quote(value)}\z/)
+          when :greater_than, :gt
+            @relation = relation.where(field.to_sym.gt => value)
+          when :less_than, :lt
+            @relation = relation.where(field.to_sym.lt => value)
+          when :greater_than_or_equal_to, :gte, :gteq
+            @relation = relation.where(field.to_sym.gte => value)
+          when :less_than_or_equal_to, :lte, :lteq
+            @relation = relation.where(field.to_sym.lte => value)
+          when :in
+            @relation = relation.where(field.to_sym.in => Array.wrap(value))
+          when :not_in, :ni
+            @relation = relation.where(field.to_sym.nin => Array.wrap(value))
+          when :is_true
+            @relation = relation.where(field => true)
+          when :is_false
+            @relation = relation.where(field => false)
+          when :is_present
+            @relation = relation.where(field.to_sym.exists => true)
+          when :is_blank
+            @relation = relation.where(field.to_sym.exists => false)
+          when :is_null
+            @relation = relation.where(field => nil)
+          when :is_not_null
+            @relation = relation.where(field.to_sym.ne => nil)
           else
             raise [field_query, value].inspect
           end
@@ -54,11 +92,12 @@ module MetaSearch
       end
 
       def metasearch_regexp
-        field_names = klass.content_columns.map(&:name)
+        # field_names = klass.content_columns.map(&:name)
+        field_names = klass.fields.map(&:second).map(&:name)
 
         conditions = MetaSearch::DEFAULT_WHERES.map {|condition| condition[0...-1]} # pop tail options
 
-        /\A(#{field_names.join('|')})_(#{conditions.join('|')})/
+        /\A(#{field_names.join('|')})_(#{conditions.join('|')})\z/
       end
 
     end

--- a/spec/features/smoke_spec.rb
+++ b/spec/features/smoke_spec.rb
@@ -5,69 +5,206 @@ require 'activeadmin'
 describe 'browse the test app' do
   let(:password) { 'foobar•secret' }
   let(:email) { 'john@doe.com' }
+  let(:admin_user) do
+    AdminUser.where(email: email).first || AdminUser.create!(email: email, password: password)
+  end
+  let(:other_email) { 'jane@doe.com' }
+  let(:other_user) do
+    AdminUser.where(email: other_email).first || AdminUser.create!(email: other_email, password: password)
+  end
 
   before do
     Mongoid.purge!
-    AdminUser.create! email: email, password: password
+    expect(admin_user).to be_persisted
+    expect(other_user).to be_persisted
   end
-  before { visit '/admin' }
 
-  it 'does something' do
-    I18n.t('active_admin.devise.login.submit').should eq('Login')
+  context 'when authorized' do
+    before do
+      visit '/admin'
 
-    # Auth
-    fill_in 'Email', with: email
-    fill_in 'Password', with: password
-    click_on 'Login'
+      I18n.t('active_admin.devise.login.submit').should eq('Login')
 
-    # New
-    click_on 'Posts'
-    click_on 'New Post'
-    fill_in 'Title', with: 'dhh screencast'
-    fill_in 'Body', with: 'is still the best intro to rails'
-
-    # Create
-    click_on 'Create Post'
-
-    within '.attributes_table.post' do
-      page.should have_content('dhh screencast')
-      page.should have_content('is still the best intro to rails')
+      # Auth
+      fill_in 'Email', with: email
+      fill_in 'Password', with: password
+      click_on 'Login'
     end
 
-    # Edit
-    click_on 'Edit Post'
-    fill_in 'Title', with: 'DHH original screencast'
+    it 'creates and edits a new post' do
+      # New
+      click_on 'Posts'
+      click_on 'New Post'
+      fill_in 'Title', with: 'dhh screencast'
+      fill_in 'Body', with: 'is still the best intro to rails'
 
-    # Update
-    click_on 'Update Post'
+      # Create
+      click_on 'Create Post'
 
-    within '.attributes_table.post' do
-      page.should have_content('DHH original screencast')
-      page.should have_content('is still the best intro to rails')
+      within '.attributes_table.post' do
+        page.should have_content('dhh screencast')
+        page.should have_content('is still the best intro to rails')
+      end
+
+      # Edit
+      click_on 'Edit Post'
+      fill_in 'Title', with: 'DHH original screencast'
+
+      # Update
+      click_on 'Update Post'
+
+      within '.attributes_table.post' do
+        page.should have_content('DHH original screencast')
+        page.should have_content('is still the best intro to rails')
+      end
+
+      # List
+      within('.breadcrumb') { click_on 'Posts' }
+      within '#index_table_posts' do
+        page.should have_content('DHH original screencast')
+        page.should have_content('is still the best intro to rails')
+      end
     end
 
-    # List
-    within('.breadcrumb') { click_on 'Posts' }
-    within '#index_table_posts' do
-      page.should have_content('DHH original screencast')
-      page.should have_content('is still the best intro to rails')
+    context 'with 1 post' do
+
+      before do
+        Post.create!(title: 'Quick Brown Fox', body: 'The quick brown fox jumps over the lazy dog.', view_count: 5, admin_user: admin_user, other_user: other_user)
+
+        click_on 'Posts'
+      end
+
+      describe 'filters' do
+        describe 'string' do
+          it 'searches by title' do
+            fill_in 'Search Title', with: 'Brown'
+            click_on 'Filter'
+
+            within '#index_table_posts' do
+              page.should have_content('Quick Brown Fox')
+            end
+
+            fill_in 'Search Title', with: 'dog'
+            click_on 'Filter'
+            page.should_not have_content('Quick Brown Fox')
+
+            fill_in 'Search Title', with: ''
+            click_on 'Filter'
+
+            page.should have_content('Displaying 1 Post')
+          end
+        end
+
+        describe 'date_range' do
+          it 'searches by created_at range' do
+            fill_in 'q[created_at_gte]', with: 1.day.ago.to_datetime.strftime("%Y-%m-%d")
+            fill_in 'q[created_at_lte]', with: 2.days.from_now.to_datetime.strftime("%Y-%m-%d")
+            click_on 'Filter'
+
+            within '#index_table_posts' do
+              page.should have_content('Quick Brown Fox')
+            end
+
+            fill_in 'q[created_at_gte]', with: 1.day.from_now.to_datetime.strftime("%Y-%m-%d")
+            click_on 'Filter'
+            page.should_not have_content('Quick Brown Fox')
+
+            fill_in 'q[created_at_gte]', with: ''
+            fill_in 'q[created_at_lte]', with: ''
+            click_on 'Filter'
+
+            page.should have_content('Displaying 1 Post')
+          end
+        end
+
+        describe 'numeric' do
+          it 'searches by created_at range', js: true do
+            within '.filter_numeric' do
+              find(:select).find('option[value=view_count_eq]').select_option
+            end
+            fill_in 'View count', with: '5'
+            click_on 'Filter'
+
+            within '#index_table_posts' do
+              page.should have_content('Quick Brown Fox')
+            end
+
+            fill_in 'View count', with: '6'
+            click_on 'Filter'
+            page.should_not have_content('Quick Brown Fox')
+
+            within '.filter_numeric' do
+              find(:select).find('option[value=view_count_lt]').select_option
+            end
+            click_on 'Filter'
+
+            within '#index_table_posts' do
+              page.should have_content('Quick Brown Fox')
+            end
+
+            within '.filter_numeric' do
+              find(:select).find('option[value=view_count_gt]').select_option
+            end
+            click_on 'Filter'
+            page.should_not have_content('Quick Brown Fox')
+
+            fill_in 'View count', with: '4'
+            click_on 'Filter'
+
+            within '#index_table_posts' do
+              page.should have_content('Quick Brown Fox')
+            end
+
+            fill_in 'View count', with: ''
+            click_on 'Filter'
+
+            page.should have_content('Displaying 1 Post')
+          end
+        end
+      end
+
+      describe 'select' do
+        it 'selects by admin_user' do
+          select email, from: 'Admin user'
+          click_on 'Filter'
+
+          within '#index_table_posts' do
+            page.should have_content('Quick Brown Fox')
+          end
+
+          select other_email, from: 'Admin user'
+          click_on 'Filter'
+          page.should_not have_content('Quick Brown Fox')
+
+          select 'Any', from: 'Admin user'
+          click_on 'Filter'
+
+          page.should have_content('Displaying 1 Post')
+        end
+      end
+
+      describe 'check_boxes' do
+        it 'checks by other_user' do
+          check email
+          click_on 'Filter'
+          page.should_not have_content('Quick Brown Fox')
+
+          check other_email
+          click_on 'Filter'
+
+          within '#index_table_posts' do
+            page.should have_content('Quick Brown Fox')
+          end
+
+          uncheck email
+          uncheck other_email
+          click_on 'Filter'
+
+          page.should have_content('Displaying 1 Post')
+        end
+      end
+
     end
-
-    # Filter
-    fill_in 'Search Title', with: 'original'
-    click_on 'Filter'
-
-    within '#index_table_posts' do
-      page.should have_content('DHH original screencast')
-    end
-
-    fill_in 'Search Title', with: 'orizinal'
-    click_on 'Filter'
-    page.should_not have_content('DHH original screencast')
-
-    fill_in 'Search Title', with: ''
-    click_on 'Filter'
-
-    page.should have_content('Displaying 1 Post')
   end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,14 @@
 ENV['RAILS_ENV'] ||= 'test'
 require 'rubygems'
 require 'bundler'
+
+if %w(true 1).include?(ENV['COVERAGE'])
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter '/test_app/'
+  end
+end
+
 Bundler.require
 
 require File.expand_path("../../test_app/config/environment", __FILE__)
@@ -10,6 +18,7 @@ require 'rspec/autorun'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
+Dir[File.join(File.expand_path("../../", __FILE__), "spec/support/**/*.rb")].each {|f| require f}
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
 RSpec.configure do |config|

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,1 +1,3 @@
-require 'capibara/rails'
+require 'capybara/rails'
+require 'capybara/poltergeist'
+Capybara.javascript_driver = :poltergeist

--- a/test_app/app/admin/posts.rb
+++ b/test_app/app/admin/posts.rb
@@ -1,3 +1,10 @@
 ActiveAdmin.register Post do
 
+  filter :title
+  filter :body
+  filter :created_at, as: :date_range
+  filter :view_count, as: :numeric
+  filter :admin_user, as: :select
+  filter :other_user, as: :check_boxes
+
 end

--- a/test_app/app/assets/javascripts/active_admin.js
+++ b/test_app/app/assets/javascripts/active_admin.js
@@ -1,1 +1,7 @@
-//= require active_admin/base
+//= require jquery
+//= require jquery_ujs
+//= require jquery.ui.core
+//= require jquery.ui.widget
+//= require jquery.ui.datepicker
+
+//= require active_admin/application

--- a/test_app/app/models/admin_user.rb
+++ b/test_app/app/models/admin_user.rb
@@ -37,4 +37,8 @@ class AdminUser
 
   ## Token authenticatable
   # field :authentication_token, :type => String
+
+  def name
+    email
+  end
 end

--- a/test_app/app/models/post.rb
+++ b/test_app/app/models/post.rb
@@ -1,6 +1,10 @@
 class Post
   include Mongoid::Document
+  include Mongoid::Timestamps
 
   field :title
   field :body
+  field :view_count, type: ::Integer, default: 0
+  belongs_to :admin_user
+  belongs_to :other_user, class_name: 'AdminUser'
 end

--- a/test_app/config/_link_mongoid_config.rb
+++ b/test_app/config/_link_mongoid_config.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'mongoid'
 root    = Pathname(File.expand_path('../..', __FILE__))
 version = Mongoid::VERSION.to_i
 


### PR DESCRIPTION
The title describes the majority of this pull request.

I used all of the terms from [MetaSearch::DEFAULT_WHERES](https://github.com/ernie/meta_search/blob/master/lib/meta_search.rb#L12-L33) and added the corresponding Mongoid queries to get the filters to work.

I added tests for string, date_range, numeric, select, and check_boxes filters as part of the smoke spec.  I also added [simplecov](https://github.com/colszowka/simplecov) so I could gauge my testing progress.  It's disabled by default, but can be enabled with:

``` bash
COVERAGE=1 bundle exec rake
```
