### PR TITLE
namespace_helper path change fix

### DIFF
--- a/lib/active_admin/mongoid/comments.rb
+++ b/lib/active_admin/mongoid/comments.rb
@@ -1,4 +1,4 @@
-require 'active_admin/comments/namespace_helper'
+require 'active_admin/orm/active_record/comments/namespace_helper'
 # ActiveAdmin::Application.allow_comments = false
 
 module ActiveAdmin


### PR DESCRIPTION
namespace_helper.rb file is moved from `active_admin/comments` (0-6-stable branch) to `active_admin/orm/active_record/comments` in the current master branch.

This fixes the `cannot load such file -- active_admin/comments/namespace_helper` while running active admin initializers.

Linking the issue https://github.com/elia/activeadmin-mongoid/issues/49#issuecomment-26697692
