### PR TITLE
Do not split the sort

### DIFF
--- a/lib/active_admin/mongoid/document.rb
+++ b/lib/active_admin/mongoid/document.rb
@@ -115,8 +115,7 @@ module ActiveAdmin::Mongoid::Document
 
     def reorder sorting
       return unscoped if sorting.blank?
-      options = sorting.split(/ |\./)
-      options.shift if options.count == 3
+      options = sorting.split(' ')
       field, order = *options
       unscoped.order_by(field => order)
     end


### PR DESCRIPTION
I came up with an issue trying to sort by an embedded attribute, so when the app sends 'order=repository.users_count_asc', it was trying to sort by the users attribute in the main collection, which does not exist.
