### PR TITLE
Fixed sorting in activeadmin 1.0

### DIFF
--- a/lib/active_admin/mongoid.rb
+++ b/lib/active_admin/mongoid.rb
@@ -12,6 +12,7 @@ require 'active_admin/mongoid/resource'
 require 'active_admin/mongoid/document'
 require 'active_admin/mongoid/helpers/collection'
 require 'active_admin/mongoid/criteria'
+require 'active_admin/mongoid/order_clause'
 
 module ActiveAdmin
   module Mongoid

--- a/lib/active_admin/mongoid/order_clause.rb
+++ b/lib/active_admin/mongoid/order_clause.rb
@@ -14,7 +14,7 @@ module ActiveAdmin
       @column.present? && @order.present?
     end
 
-    def to_sql
+    def to_sql(options=nil)
       [@column, ' ', @order].compact.join
     end
   end

--- a/lib/active_admin/mongoid/order_clause.rb
+++ b/lib/active_admin/mongoid/order_clause.rb
@@ -1,0 +1,21 @@
+module ActiveAdmin
+  class OrderClause
+    attr_reader :field, :order
+
+    def initialize(clause)
+      clause =~ /^([\w\_\.]+)_(desc|asc)$/
+      @column = $1
+      @order = $2
+
+      @field = @column
+    end
+
+    def valid?
+      @column.present? && @order.present?
+    end
+
+    def to_sql
+      [@column, ' ', @order].compact.join
+    end
+  end
+end

--- a/spec/unit/order_clause_spec.rb
+++ b/spec/unit/order_clause_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe ActiveAdmin::OrderClause do
+  subject { described_class.new clause }
+
+  let(:application) { ActiveAdmin::Application.new }
+  let(:namespace)   { ActiveAdmin::Namespace.new application, :admin }
+
+  describe 'sale.price_asc (embedded document)' do
+    let(:clause) { 'sale.price_asc' }
+
+    it { should be_valid }
+    its(:field) { should == 'sale.price' }
+    its(:order) { should == 'asc' }
+
+    specify '#to_sql joins field and order' do
+      expect(subject.to_sql).to eq 'sale.price asc'
+    end
+  end
+
+  describe 'virtual_column_desc' do
+    let(:clause) { 'virtual_column_desc' }
+
+    it { should be_valid }
+    its(:field) { should == 'virtual_column' }
+    its(:order) { should == 'desc' }
+
+    specify '#to_sql' do
+      expect(subject.to_sql).to eq 'virtual_column desc'
+    end
+  end
+
+  describe '_asc' do
+    let(:clause) { '_asc' }
+
+    it { should_not be_valid }
+  end
+
+  describe 'nil' do
+    let(:clause) { nil }
+
+    it { should_not be_valid }
+  end
+end


### PR DESCRIPTION
This fixes Sorting on Active Admin 1.0.0.pre and Rails 4.0.4

I can't run the spec suite within activeadmin-mongoid, but they do pass when I run from my rails app,
 i.e. copy spec/unit/order_clause_spec.rb to railsapp/spec/models/

The spec suite needs to be fixed here.
