### PR TITLE
Activeadmin 1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 
 
 # Test app stuff
-gem 'rails',        '~> 4.0.0'
+gem 'rails',        '~> 4.0.5'
 
 # Waiting for the release
 gem 'activeadmin', github: 'gregbell/active_admin'
@@ -16,9 +16,10 @@ gem 'mongoid',     github: 'mongoid/mongoid'
 gem 'sass-rails',   '~> 4.0.0'
 gem 'uglifier',     '>= 1.3.0'
 gem 'coffee-rails', '~> 4.0.0'
+gem 'devise'
 
 # Bundler hacks
-gem 'railties',     '~> 4.0.0' # forced to overcome coffee-rails
+gem 'railties',     '~> 4.0.5' # forced to overcome coffee-rails
 
 gem 'jquery-rails'
 gem 'turbolinks'

--- a/lib/active_admin/mongoid.rb
+++ b/lib/active_admin/mongoid.rb
@@ -12,6 +12,7 @@ require 'active_admin/mongoid/resource'
 require 'active_admin/mongoid/document'
 require 'active_admin/mongoid/helpers/collection'
 require 'active_admin/mongoid/criteria'
+require 'active_admin/mongoid/order_clause'
 
 module ActiveAdmin
   module Mongoid

--- a/lib/active_admin/mongoid.rb
+++ b/lib/active_admin/mongoid.rb
@@ -1,9 +1,9 @@
+require 'rails'
+require 'devise'
+require 'mongoid'
 require 'active_admin/mongoid/version'
 require 'active_support/core_ext' # needed by ransack
 require 'active_admin'
-require 'devise'
-require 'rails'
-require 'mongoid'
 
 require 'active_admin/mongoid/comments'
 require 'active_admin/mongoid/adaptor'

--- a/lib/active_admin/mongoid/order_clause.rb
+++ b/lib/active_admin/mongoid/order_clause.rb
@@ -14,7 +14,7 @@ module ActiveAdmin
       @column.present? && @order.present?
     end
 
-    def to_sql
+    def to_sql(options=nil)
       [@column, ' ', @order].compact.join
     end
   end

--- a/lib/active_admin/mongoid/order_clause.rb
+++ b/lib/active_admin/mongoid/order_clause.rb
@@ -1,0 +1,21 @@
+module ActiveAdmin
+  class OrderClause
+    attr_reader :field, :order
+
+    def initialize(clause)
+      clause =~ /^([\w\_\.]+)_(desc|asc)$/
+      @column = $1
+      @order = $2
+
+      @field = @column
+    end
+
+    def valid?
+      @column.present? && @order.present?
+    end
+
+    def to_sql
+      [@column, ' ', @order].compact.join
+    end
+  end
+end

--- a/lib/active_admin/mongoid/resource.rb
+++ b/lib/active_admin/mongoid/resource.rb
@@ -1,24 +1,15 @@
-# module ActiveAdmin
-#   class Resource
-#
-#     module Naming
-#
-#       # Returns a name used to uniquely identify this resource
-#       # this should be an instance of ActiveAdmin:Resource::Name, which responds to
-#       # #singular, #plural, #route_key, #human etc.
-#       def resource_name
-#         custom_name = @options[:as] && @options[:as].gsub(/\s/,'')
-#         @resource_name ||= if custom_name || !resource_class.respond_to?(:model_name)
-#             Resource::Name.new(resource_class, custom_name)
-#           else
-#             Resource::Name.new(resource_class)
-#           end
-#       end
-#
-#     end
-#
-#   end
-# end
+module ActiveAdmin
+
+  class Resource
+
+    private
+
+    def method_for_find
+      resources_configuration[:self][:finder] || :find
+    end
+
+  end
+end
 
 # ActiveAdmin::Resource # autoload
 # class ActiveAdmin::Resource

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,12 +31,12 @@ RSpec.configure do |config|
   # config.mock_with :rr
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  # config.use_transactional_fixtures = true
 
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of

--- a/spec/unit/order_clause_spec.rb
+++ b/spec/unit/order_clause_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe ActiveAdmin::OrderClause do
+  subject { described_class.new clause }
+
+  let(:application) { ActiveAdmin::Application.new }
+  let(:namespace)   { ActiveAdmin::Namespace.new application, :admin }
+
+  describe 'sale.price_asc (embedded document)' do
+    let(:clause) { 'sale.price_asc' }
+
+    it { should be_valid }
+    its(:field) { should == 'sale.price' }
+    its(:order) { should == 'asc' }
+
+    specify '#to_sql joins field and order' do
+      expect(subject.to_sql).to eq 'sale.price asc'
+    end
+  end
+
+  describe 'virtual_column_desc' do
+    let(:clause) { 'virtual_column_desc' }
+
+    it { should be_valid }
+    its(:field) { should == 'virtual_column' }
+    its(:order) { should == 'desc' }
+
+    specify '#to_sql' do
+      expect(subject.to_sql).to eq 'virtual_column desc'
+    end
+  end
+
+  describe '_asc' do
+    let(:clause) { '_asc' }
+
+    it { should_not be_valid }
+  end
+
+  describe 'nil' do
+    let(:clause) { nil }
+
+    it { should_not be_valid }
+  end
+end


### PR DESCRIPTION
This makes this rails4 branch compatible with upstream active-admin 1.0 from master

the lib/active_admin/mongoid/resource.rb change is the equivalent as adding to every admin resource the following:

``` ruby
ActiveAdmin.register User do
  controller do
    defaults finder: :find
  end
end
```
