### PR TITLE
Fixes sidebar filter on ActiveAdmin index pages. Rendering the sidebar f...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 
 
 # Test app stuff
-gem 'rails',        '~> 4.0.0'
+gem 'rails',        '~> 4.0.5'
 
 # Waiting for the release
 gem 'activeadmin', github: 'gregbell/active_admin'
@@ -16,9 +16,10 @@ gem 'mongoid',     github: 'mongoid/mongoid'
 gem 'sass-rails',   '~> 4.0.0'
 gem 'uglifier',     '>= 1.3.0'
 gem 'coffee-rails', '~> 4.0.0'
+gem 'devise'
 
 # Bundler hacks
-gem 'railties',     '~> 4.0.0' # forced to overcome coffee-rails
+gem 'railties',     '~> 4.0.5' # forced to overcome coffee-rails
 
 gem 'jquery-rails'
 gem 'turbolinks'

--- a/lib/active_admin/mongoid.rb
+++ b/lib/active_admin/mongoid.rb
@@ -5,18 +5,20 @@ require 'devise'
 require 'rails'
 require 'mongoid'
 
-require 'active_admin/mongoid/comments'
+require 'active_admin/mongoid/filters/view_helper'
+require 'active_admin/mongoid/helpers/collection'
 require 'active_admin/mongoid/adaptor'
+require 'active_admin/mongoid/comments'
+require 'active_admin/mongoid/criteria'
+require 'active_admin/mongoid/document'
 require 'active_admin/mongoid/filter_form_builder'
 require 'active_admin/mongoid/resource'
-require 'active_admin/mongoid/document'
-require 'active_admin/mongoid/helpers/collection'
-require 'active_admin/mongoid/criteria'
 
 module ActiveAdmin
   module Mongoid
     class Railtie < ::Rails::Railtie
       config.after_initialize do
+        require 'active_admin/mongoid/resource_controller/data_access'
         I18n.backend.reload!
       end
     end

--- a/lib/active_admin/mongoid.rb
+++ b/lib/active_admin/mongoid.rb
@@ -1,9 +1,9 @@
+require 'rails'
+require 'devise'
+require 'mongoid'
 require 'active_admin/mongoid/version'
 require 'active_support/core_ext' # needed by ransack
 require 'active_admin'
-require 'devise'
-require 'rails'
-require 'mongoid'
 
 require 'active_admin/mongoid/filters/view_helper'
 require 'active_admin/mongoid/helpers/collection'
@@ -12,6 +12,7 @@ require 'active_admin/mongoid/comments'
 require 'active_admin/mongoid/criteria'
 require 'active_admin/mongoid/document'
 require 'active_admin/mongoid/filter_form_builder'
+require 'active_admin/mongoid/order_clause'
 require 'active_admin/mongoid/resource'
 
 module ActiveAdmin

--- a/lib/active_admin/mongoid/filters/view_helper.rb
+++ b/lib/active_admin/mongoid/filters/view_helper.rb
@@ -23,7 +23,8 @@ module ActiveAdmin
               link_to(I18n.t('active_admin.filters.buttons.clear'), '#', :class => 'clear_filters_btn') +
               hidden_field_tags_for(params, :except => [:q, :page])
           end
-          f.form_buffers.last + ::ActiveSupport::SafeBuffer.new(search_filters_html) + buttons
+          # form_buffers removed from main activeadmin branch
+          # f.form_buffers.last + ::ActiveSupport::SafeBuffer.new(search_filters_html) + buttons
         end
       end
     end

--- a/lib/active_admin/mongoid/filters/view_helper.rb
+++ b/lib/active_admin/mongoid/filters/view_helper.rb
@@ -1,0 +1,31 @@
+module ActiveAdmin
+  module Filters
+    module ViewHelper
+      def active_admin_filters_form_for(search, filters, options = {})
+        defaults = { :builder => ActiveAdmin::Filters::FormBuilder,
+          :url => collection_path,
+          :html => {:class => 'filter_form'} }
+        required = { :html => {:method => :get},
+          :as => :q }
+        options  = defaults.deep_merge(options).deep_merge(required)
+
+        form_for search.base.new, options do |f|
+          search_filters_html = ""
+          filters.each do |attribute, opts|
+            next if opts.key?(:if)     && !call_method_or_proc_on(self, opts[:if])
+            next if opts.key?(:unless) &&  call_method_or_proc_on(self, opts[:unless])
+            search_filters_html += f.label(attribute.to_s, opts[:label])
+            value = params.has_key?(:q) ? params[:q][attribute] : nil
+            search_filters_html += f.text_field(attribute, opts.except(:if, :unless).merge(:value => value))
+          end
+          buttons = content_tag :div, :class => "buttons" do
+            f.submit(I18n.t('active_admin.filters.buttons.filter')) +
+              link_to(I18n.t('active_admin.filters.buttons.clear'), '#', :class => 'clear_filters_btn') +
+              hidden_field_tags_for(params, :except => [:q, :page])
+          end
+          f.form_buffers.last + ::ActiveSupport::SafeBuffer.new(search_filters_html) + buttons
+        end
+      end
+    end
+  end
+end

--- a/lib/active_admin/mongoid/filters/view_helper.rb
+++ b/lib/active_admin/mongoid/filters/view_helper.rb
@@ -23,8 +23,7 @@ module ActiveAdmin
               link_to(I18n.t('active_admin.filters.buttons.clear'), '#', :class => 'clear_filters_btn') +
               hidden_field_tags_for(params, :except => [:q, :page])
           end
-          # form_buffers removed from main activeadmin branch
-          # f.form_buffers.last + ::ActiveSupport::SafeBuffer.new(search_filters_html) + buttons
+          f.form_buffers.last + ::ActiveSupport::SafeBuffer.new(search_filters_html) + buttons
         end
       end
     end

--- a/lib/active_admin/mongoid/order_clause.rb
+++ b/lib/active_admin/mongoid/order_clause.rb
@@ -1,0 +1,21 @@
+module ActiveAdmin
+  class OrderClause
+    attr_reader :field, :order
+
+    def initialize(clause)
+      clause =~ /^([\w\_\.]+)_(desc|asc)$/
+      @column = $1
+      @order = $2
+
+      @field = @column
+    end
+
+    def valid?
+      @column.present? && @order.present?
+    end
+
+    def to_sql(options=nil)
+      [@column, ' ', @order].compact.join
+    end
+  end
+end

--- a/lib/active_admin/mongoid/resource.rb
+++ b/lib/active_admin/mongoid/resource.rb
@@ -1,24 +1,15 @@
-# module ActiveAdmin
-#   class Resource
-#
-#     module Naming
-#
-#       # Returns a name used to uniquely identify this resource
-#       # this should be an instance of ActiveAdmin:Resource::Name, which responds to
-#       # #singular, #plural, #route_key, #human etc.
-#       def resource_name
-#         custom_name = @options[:as] && @options[:as].gsub(/\s/,'')
-#         @resource_name ||= if custom_name || !resource_class.respond_to?(:model_name)
-#             Resource::Name.new(resource_class, custom_name)
-#           else
-#             Resource::Name.new(resource_class)
-#           end
-#       end
-#
-#     end
-#
-#   end
-# end
+module ActiveAdmin
+
+  class Resource
+
+    private
+
+    def method_for_find
+      resources_configuration[:self][:finder] || :find
+    end
+
+  end
+end
 
 # ActiveAdmin::Resource # autoload
 # class ActiveAdmin::Resource

--- a/lib/active_admin/mongoid/resource_controller/data_access.rb
+++ b/lib/active_admin/mongoid/resource_controller/data_access.rb
@@ -1,0 +1,34 @@
+module ActiveAdmin
+  class ResourceController < BaseController
+    module DataAccess
+      protected
+
+      def collection
+        get_collection_ivar || begin
+          conditions = params[:q].nil? ? {} : params[:q].clone
+          convert_date_conditions!(conditions)
+          collection = find_collection.where(conditions)
+          authorize! Authorization::READ, active_admin_config.resource_class
+          set_collection_ivar collection
+        end
+      end
+
+      private
+
+      def convert_date_conditions!(conditions)
+        if conditions.is_a?(Hash)
+          delete_keys = []
+          date_conditions = {}
+          conditions.each do |key, value|
+            if !resource_class.fields[key].nil? && resource_class.fields[key].type == DateTime
+              date_conditions.merge!({key.to_sym.gte => DateTime.parse(value).beginning_of_day, key.to_sym.lte => DateTime.parse(value).end_of_day})
+              delete_keys << key
+            end
+          end
+          conditions.delete(delete_keys)
+          conditions.merge!(date_conditions)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_admin/mongoid/version.rb
+++ b/lib/active_admin/mongoid/version.rb
@@ -1,5 +1,5 @@
 module ActiveAdmin
   module Mongoid
-    VERSION = '0.2.1'
+    VERSION = '0.2.2'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,12 +31,12 @@ RSpec.configure do |config|
   # config.mock_with :rr
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  # config.use_transactional_fixtures = true
 
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of

--- a/spec/unit/order_clause_spec.rb
+++ b/spec/unit/order_clause_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe ActiveAdmin::OrderClause do
+  subject { described_class.new clause }
+
+  let(:application) { ActiveAdmin::Application.new }
+  let(:namespace)   { ActiveAdmin::Namespace.new application, :admin }
+
+  describe 'sale.price_asc (embedded document)' do
+    let(:clause) { 'sale.price_asc' }
+
+    it { should be_valid }
+    its(:field) { should == 'sale.price' }
+    its(:order) { should == 'asc' }
+
+    specify '#to_sql joins field and order' do
+      expect(subject.to_sql).to eq 'sale.price asc'
+    end
+  end
+
+  describe 'virtual_column_desc' do
+    let(:clause) { 'virtual_column_desc' }
+
+    it { should be_valid }
+    its(:field) { should == 'virtual_column' }
+    its(:order) { should == 'desc' }
+
+    specify '#to_sql' do
+      expect(subject.to_sql).to eq 'virtual_column desc'
+    end
+  end
+
+  describe '_asc' do
+    let(:clause) { '_asc' }
+
+    it { should_not be_valid }
+  end
+
+  describe 'nil' do
+    let(:clause) { nil }
+
+    it { should_not be_valid }
+  end
+end


### PR DESCRIPTION
...ilter will no longer use Ransack but directly use formtastic and pull values from params[:q]. Querying of index collection also uses query from params instead of going through Ransack. Currently the index filters will support exact match on BSON::Id, String, Int, Symbols, and DateTime (matched on day).

fixes #52
