### PR TITLE
Rails 4 & Mongoid 6

### DIFF
--- a/activeadmin-mongoid.gemspec
+++ b/activeadmin-mongoid.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
   gem.version       = ActiveAdmin::Mongoid::VERSION
   gem.license       = 'MIT'
 
-  gem.add_runtime_dependency 'mongoid',         '~> 5.0'
-  gem.add_runtime_dependency 'rails',           '~> 4.0'
+  gem.add_runtime_dependency 'mongoid',         '>= 5.0'
+  gem.add_runtime_dependency 'rails',           '>= 4.0'
   gem.add_runtime_dependency 'activeadmin',     ['>= 0.6.1', '< 2']
 
   gem.add_development_dependency 'rspec-rails',  '~> 2.14'


### PR DESCRIPTION
Enable use mongoid 6. No APIs changes from mongoid 5 to 6 https://docs.mongodb.com/ruby-driver/master/tutorials/6.0.0/mongoid-upgrade/

Rails 5 I will test
