### PR TITLE
Security updates (#117)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 # development dependencies will be added by default to the :development group.
 gemspec
 
-gem 'ransack', github: 'activerecord-hackery/ransack'
+gem 'ransack', github: 'activerecord-hackery/ransack', ref: 'c869fc210500'
 
 # Test app stuff
 

--- a/activeadmin-mongoid.gemspec
+++ b/activeadmin-mongoid.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_runtime_dependency 'mongoid',     ['~> 6.0.3']
-  gem.add_runtime_dependency 'activeadmin', ['>= 1.0.0']
+  gem.add_runtime_dependency 'activeadmin', ['<= 1.1.0']
   gem.add_runtime_dependency 'jquery-rails'
   gem.add_runtime_dependency 'sass-rails',  ['>= 3.1.4', '<= 5.0.6']
   # gem.add_runtime_dependency 'meta_search',  '~> 1.1.3'

--- a/test_app/Gemfile
+++ b/test_app/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'activeadmin-mongoid', path: '../'
-gem 'activeadmin', '~> 1.1.0'
+gem 'activeadmin', '<= 1.1.0'
 
 # Test app stuff
 

--- a/test_app/Gemfile.lock
+++ b/test_app/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
+    crass (1.0.3)
     devise (4.3.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -134,7 +135,8 @@ GEM
       mongoid
     launchy (2.4.3)
       addressable (~> 2.3)
-    loofah (2.0.3)
+    loofah (2.2.2)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
@@ -143,7 +145,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_mime (0.1.4)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.3)
     mongo (2.4.3)
       bson (>= 4.2.1, < 5.0.0)
@@ -151,8 +153,8 @@ GEM
       activemodel (~> 5.0)
       mongo (~> 2.3)
     nio4r (2.1.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
     poltergeist (1.16.0)
       capybara (~> 2.1)
@@ -268,4 +270,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.15.4
+   1.16.0.pre.3


### PR DESCRIPTION
* Update loofah and nokogiri

* lock AA <= 1.1, newer breaks

* lock ransack to commit