### PR TITLE
Avoid to create filters for embedded fields

### DIFF
--- a/lib/active_admin/mongoid/filters/resource_extension.rb
+++ b/lib/active_admin/mongoid/filters/resource_extension.rb
@@ -3,8 +3,8 @@ require 'active_admin/filters/resource_extension'
 module ActiveAdmin::Filters::ResourceExtension
   def default_association_filters
     if resource_class.respond_to?(:reflect_on_all_associations)
-      filtered = resource_class.reflect_on_all_associations.reject { |e| [:embeds_many, :embeds_one].include? e.macro }
-      poly, not_poly = filtered.partition{ |r| r.macro == :belongs_to && r.options[:polymorphic] }
+      without_embedded = resource_class.reflect_on_all_associations.reject { |e| [:embeds_many, :embeds_one].include? e.macro }
+      poly, not_poly = without_embedded.partition{ |r| r.macro == :belongs_to && r.options[:polymorphic] }
 
       filters = poly.map(&:foreign_type) + not_poly.map(&:name)
       filters.map &:to_sym

--- a/lib/active_admin/mongoid/filters/resource_extension.rb
+++ b/lib/active_admin/mongoid/filters/resource_extension.rb
@@ -3,7 +3,8 @@ require 'active_admin/filters/resource_extension'
 module ActiveAdmin::Filters::ResourceExtension
   def default_association_filters
     if resource_class.respond_to?(:reflect_on_all_associations)
-      poly, not_poly = resource_class.reflect_on_all_associations.partition{ |r| r.macro == :belongs_to && r.options[:polymorphic] }
+      filtered = resource_class.reflect_on_all_associations.reject { |e| [:embeds_many, :embeds_one].include? e.macro }
+      poly, not_poly = filtered.partition{ |r| r.macro == :belongs_to && r.options[:polymorphic] }
 
       filters = poly.map(&:foreign_type) + not_poly.map(&:name)
       filters.map &:to_sym


### PR DESCRIPTION
Ransack was failing when trying to create filters for embedded fields
```
undefined method `[embedded_field]_eq' for #<Ransack::Search:0x00007fe8ba471e90>
```