### PR TITLE
Change Ruby supported minimum to 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 services:
   - mongodb
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # ActiveAdmin-Mongoid
+[![Build Status](https://travis-ci.org/activeadmin/activeadmin-mongoid.svg?branch=master)](https://travis-ci.org/activeadmin/activeadmin-mongoid)
 
 ## Updates
 
 ActiveAdmin is holding off on pulling Mongoid support into the core ActiveAdmin application.  This repo was pulled into the ActiveAdmin org from previous work done by Elia Schito, and will be maintained by Nic Boie, JD Guzman, Elia Schito and other ActiveAdmin and community members.
 
-### Requirements for version 0.7.0
-* Ruby 2.2.2 or greater. (Note, ruby-2.4.0 fails specs, see [this issue](https://github.com/DatabaseCleaner/database_cleaner/issues/466))
+### Requirements for version 0.8.0
+* Ruby 2.3.0 or greater. (Note, ruby-2.4.0 fails specs, see [this issue](https://github.com/DatabaseCleaner/database_cleaner/issues/466))
 * Tested working on Rails 5.1.x
 * Mongoid 6.x (**WARNING**:, using a Mongoid version >= 6.1.x has resulted in a fair amount of errors seen in the wild.  Test your upgrade very carefully with any apps in which you're using this gem with Mongoid >= 6.1.x!)
 * ActiveAdmin 1.3
@@ -18,9 +19,6 @@ ActiveAdmin is holding off on pulling Mongoid support into the core ActiveAdmin 
 ## ♻️ INFO
 
 This gem has been brought into the ActiveAdmin org for support and maintenance.
-
-<!-- [![Build Status](https://secure.travis-ci.org/elia/activeadmin-mongoid.svg?branch=master)](http://travis-ci.org/elia/activeadmin-mongoid)
-[![Gem Version](https://badge.fury.io/rb/activeadmin-mongoid.svg)](http://badge.fury.io/rb/activeadmin-mongoid) -->
 
 # ActiveAdmin::Mongoid
 

--- a/activeadmin-mongoid.gemspec
+++ b/activeadmin-mongoid.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = ActiveAdmin::Mongoid::VERSION
   gem.license       = 'MIT'
+  
+  gem.required_ruby_version = '>= 2.3'
 
   gem.add_runtime_dependency 'mongoid',     ['~> 6.0']
   gem.add_runtime_dependency 'activeadmin', '>= 1.3.0'

--- a/lib/active_admin/mongoid/version.rb
+++ b/lib/active_admin/mongoid/version.rb
@@ -1,5 +1,5 @@
 module ActiveAdmin
   module Mongoid
-    VERSION = '0.7.0'
+    VERSION = '0.8.0'
   end
 end


### PR DESCRIPTION
Ruby 2.2 is no longer supported and it was dropped by ActiveAdmin so I think we should do the same.