### PR TITLE
Handling the unneeded migration filecreation using method_added capture approach

### DIFF
--- a/lib/activeadmin-mongoid.rb
+++ b/lib/activeadmin-mongoid.rb
@@ -1,1 +1,29 @@
 require 'active_admin/mongoid'
+require "rails/generators/actions"
+require "rails/generators/named_base"
+
+# Considering the Rails::Generators::NamedBase is one of the nearest ancestor to
+# ActiveAdmin::Generators::InstallGenerator, we can open the class and an empty create_migration
+# to the class(which will overridden by other subclasses). We can specifically focus on the
+# ActiveAdmin::Generators::InstallGenerator class and apply remove_method during the method_added call
+# and thereby pushing ActiveAdmin::Generators::InstallGenerator to use our empty create_migrations method.
+
+Rails::Generators::NamedBase.class_eval do
+
+  def create_migrations
+  end
+
+  def self.inherited(klass)
+    super
+    if klass.name == "ActiveAdmin::Generators::InstallGenerator"
+
+      klass.class_eval do 
+        def self.method_added(method_name)
+          super
+          remove_method method_name if method_name == :create_migrations
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
This fixes #137 (Migration related to comments getting created during `rails g active_admin:install`)

Considering the Rails::Generators::NamedBase is one of the nearest ancestor to **ActiveAdmin::Generators::InstallGenerator,** we can open the class and an empty create_migration to the class(which will overridden by other subclasses). We can specifically focus on the **ActiveAdmin::Generators::InstallGenerator** class and apply `remove_method` during the `method_added` call and thereby pushing **ActiveAdmin::Generators::InstallGenerator** to use our empty `create_migrations` method.

Verified locally and the specs are passing in local as well. 

@boie0025 @grzegorz-jakubiak Please let me know if this changes doesn't a right fit for the facing issue.

Signed-off-by: Naveen Honest Raj K <naveendurai19@gmail.com>